### PR TITLE
UI: Make Picture/Camera screens fit device

### DIFF
--- a/lib/screens/display_picture.dart
+++ b/lib/screens/display_picture.dart
@@ -6,24 +6,33 @@ import '../theme.dart';
 
 class DisplayPictureScreen extends StatelessWidget {
   final String imagePath;
-
   const DisplayPictureScreen({super.key, required this.imagePath});
 
   @override
   Widget build(BuildContext context) {
+    var buttonSavePicture = buttonTemplate(
+      text: "SAVE PICTURE",
+      onPressed: () => {Navigator.pop(context, imagePath)}
+    );
+
     return Scaffold(
-        body: SingleChildScrollView(
-            child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-          Image.file(File(imagePath)),
-          Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 50),
-              child: Center(
-                child: buttonTemplate(
-                    text: "SAVE PICTURE",
-                    onPressed: () => {Navigator.pop(context, imagePath)}),
-              ))
-        ])));
+      body: Container(
+        margin: const EdgeInsets.fromLTRB(8, 32, 8, 16),
+        child: Column(
+          children: [
+            Flexible(
+              flex: 2,
+              child: Image.file(File(imagePath)),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              flex: 0,
+              child: buttonSavePicture
+            ),
+          ],
+        ),
+      )
+    );
+
   }
 }

--- a/lib/screens/take_picture.dart
+++ b/lib/screens/take_picture.dart
@@ -39,7 +39,7 @@ class TakePictureScreenState extends State<TakePictureScreen> {
 
   @override
   Widget build(BuildContext context) {
-    var button = buttonTemplate(
+    var buttonTakePicture = buttonTemplate(
         text: "TAKE PICTURE",
         onPressed: () async {
           try {
@@ -63,21 +63,30 @@ class TakePictureScreenState extends State<TakePictureScreen> {
         });
 
     return Scaffold(
-      body: FutureBuilder<void>(
-        future: _initializeControllerFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            return SingleChildScrollView(child:  Column(children: [
-              CameraPreview(_controller),
-              const SizedBox(height: 40.0),
-              button
-            ]));
-          } else {
-            return const Center(child: CircularProgressIndicator(
-              color: Colors.white,
-            ));
-          }
-        },
+      body: Container(
+        margin: const EdgeInsets.fromLTRB(8, 32, 8, 16),
+        child: Column(
+          children: [
+            Flexible(
+              flex: 2,
+              child: FutureBuilder<void>(
+                future: _initializeControllerFuture,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.done) {
+                    return CameraPreview(_controller);
+                  } else {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                }
+              )
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              flex: 0,
+              child: buttonTakePicture
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Hi! This PR is related to #17 - it takes users a bit of time to realize you need to scroll to see the Take Picture/Save Picture buttons. Here's what I did:

* Replaced `SingleChildScrollView` with a `Container`. This avoids having to scroll to see components, and allows us to have a safety margin around the container, preventing components from touching the screen's edges.
* Used `Expanded` and `Flexible` to dynamically resize the components (the button takes up as much space as it needs first, and the rest is given to the preview)
* Added a `SizedBox` between the camera preview and the screen's respective button to avoid them touching.

Preview on phone:
<p align="center">
  <img src="https://github.com/abertschi/water-me/assets/59916540/3c03b53a-704a-463f-b252-970d2288ee05" width=300>
  <img src="https://github.com/abertschi/water-me/assets/59916540/bc6e7960-9dc6-4950-a0e6-2c7614076d76" width=300>
</p>

Preview on tablet:
<p align="center">
  <img src="https://github.com/abertschi/water-me/assets/59916540/f9ccb859-c3cf-40b9-8e37-c54fd5bc8abf" width=300>
  <img src="https://github.com/abertschi/water-me/assets/59916540/b254b3b7-1bcc-4aae-819e-975df278ddda" width=300>
</p>

I think Flutter has a way of adding overlays to the camera controller, which would allow for a prettier full-screen camera, but I'm not familiar with it, and I think for the time being, this could be a good alternative.

Please let me know if you have any suggestions or comments. I'd be happy to help :)